### PR TITLE
improve `cp`

### DIFF
--- a/src/utils/cp/cp.rs
+++ b/src/utils/cp/cp.rs
@@ -1,34 +1,67 @@
 // https://man.archlinux.org/man/cp.1
 
+use std::borrow::Cow;
 use std::error::Error;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-fn cp(src: &str, dst: &str, is_recursive: bool) -> Result<(), Box<dyn Error>> {
-    fs::metadata(src)?;
-    
-    let src_path = Path::new(src);
-    let mut dst_path = PathBuf::from(dst);
+fn copy_file(src_path: Cow<Path>, dst_path: Cow<Path>) -> Result<(), Box<dyn Error>> {
+    fs::copy(&src_path, &dst_path)?;
+    println!("Copied '{}' to '{}'", src_path.display(), dst_path.display());
+    Ok(())
+}
 
-    if dst_path.is_dir() {
-        dst_path.push(src);
-    }
-    
-    if is_recursive {
-        fs::create_dir(&dst_path)?;
-        let entries = fs::read_dir(&src_path)?;
+fn copy_directory(src_path: Cow<Path>, dst_path: Cow<Path>, is_recursive: bool) -> Result<(), Box<dyn Error>> {
+    fs::create_dir_all(&dst_path)?;
 
-        for entry in entries {
-            let file = entry?;
-            let new_dst = dst_path.join(file.file_name());
-            cp(&file.path().to_string_lossy(), &new_dst.to_string_lossy(), true)?;
+    for entry in fs::read_dir(&src_path)? {
+        let entry_path = Cow::from(
+            entry?.path()
+        );
+
+        let new_dst = match entry_path.file_name() {
+            Some(file_name) => Cow::from(dst_path.join(file_name)),
+            None => dst_path.clone(),  // this should never happen
+        };
+
+        if entry_path.is_file() {
+            copy_file(entry_path, new_dst)?;
+        } else if entry_path.is_dir() && is_recursive {
+            copy_directory(entry_path, new_dst, is_recursive)?;
+        } else {
+            // invalid path (shouldn't happen as it's a result of fs::read_dir, but I am not sure)
+            // My suggestion is to ignore this case and print a warning.
         }
-    } else {
-        fs::copy(&src_path, &dst_path)?;
     }
-    println!("Copied '{} to '{}'", src, dst);
 
     Ok(())
+}
+
+fn cp(src: &str, dst: &str, is_recursive: bool) -> Result<(), Box<dyn Error>> {
+    let src_path = Cow::from(Path::new(src));
+    let mut dst_path = Cow::from(Path::new(dst));
+
+    // ToDo: Handle cases when passing invalid paths and add some errors on '// invalid path'.
+    // For example:
+    // - src = "/directory"
+    // - dst = "file.txt"
+    //
+    // I am not sure what behavior is desired in such cases,
+    // so I am leaving it for @wick3dr0se to decide and implement
+
+    if dst_path.is_dir() {
+        dst_path.to_mut().push(&src_path);
+    }
+
+    if src_path.is_dir() {
+        dst_path.to_mut().push(&src_path);
+        copy_directory(src_path, dst_path, is_recursive)
+    } else if src_path.is_file() {
+        copy_file(src_path, dst_path)
+    } else {
+        // invalid path - src_path doesn't exist
+        Ok(())
+    }
 }
 
 fn main() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
### Changes
- Fixed issue when copying deep directories _(instead of copying files, it created a directory with the name of the file)_
- Fixed print message when copying files _(message was printed even when no files were copied)_
- Decreased recursive calls
- Decreased heap allocations

Memory usage before:
```
total_blocks: 389,
total_bytes: 26380,
curr_blocks: 6,
curr_bytes: 1293,
max_blocks: 104,
max_bytes: 5057,
```
Memory usage after:
```
total_blocks: 354,
total_bytes: 26194,
curr_blocks: 6,
curr_bytes: 1293,
max_blocks: 83,
max_bytes: 4178,
```

_(tested with `dhat`)_

### To Do
- Some error handling decisions related to path validation. I am not sure what the desired behavior should be, so I am leaving it as is.